### PR TITLE
Now logging 'switched user name' when AuthenticationSwitchUserEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Spring Security Eventlog Plugin
 
 This plugin creates a simple log of spring security events.  Each time
 a user logs in or logs out, a log entry will created, storing the
-remote address, session id, user name, event name, and the time at
-which the event occured.
+remote address, session id, user name, event name, switched user name,
+and the time at which the event occurred.
 
 Events are logged to a table named SPRING_SECURITY_EVENT, mapped to a
 domain object ca.redtoad.eventlog.SpringSecurityEvent.
@@ -16,6 +16,7 @@ Each event has the following fields:
 * sessionId - the user's session
 * eventName - the name of the event
 * remoteAddress - the user's IP address
+* switchedUsername - username that is being switched to
 * dateCreated - the event's timestamp
 
 Some of the event names that are captured:
@@ -23,6 +24,7 @@ Some of the event names that are captured:
 * AuthenticationFailureBadCredentialsEvent - a bad username or password
 * AuthenticationSuccessEvent - a successful login
 * InteractiveAuthenticationSuccessEvent - a successful login where the user entered his/her username and password
+* AuthenticationSwitchUserEvent - user having ROLE_SWITCH_USER has assumed the identity of a (likely different) user
 * Logout - a user logged out interactively
 
 
@@ -51,6 +53,10 @@ In your `Config.groovy`, tell grails to your own event logger class:
 
 Changelog
 ---------
+
+* Changes in spring-security-eventlog 0.2-ressom
+   * added logging of 'switched user name' when a AuthenticationSwitchUserEvent occurs
+   * small cleanup of plugin definition
 
 * Changes in spring-security-eventlog 0.2
 

--- a/SpringSecurityEventlogGrailsPlugin.groovy
+++ b/SpringSecurityEventlogGrailsPlugin.groovy
@@ -26,7 +26,7 @@ class SpringSecurityEventlogGrailsPlugin {
     def scm = [ url: "http://github.com/ataylor284/spring-security-eventlog" ]
 
     def doWithSpring = {
-        def eventLoggerClass = ConfigurationHolder.config.grails.plugins.springsecurity.eventlog.eventLogger ?: SpringSecurityEventLogger
+        def eventLoggerClass = application.config.grails.plugins.springsecurity.eventlog.eventLogger ?: SpringSecurityEventLogger
         springSecurityEventLogger(eventLoggerClass)
 
         // normally these two beans are instantiated only if
@@ -35,7 +35,7 @@ class SpringSecurityEventlogGrailsPlugin {
         securityEventListener(SecurityEventListener)
         authenticationEventPublisher(DefaultAuthenticationEventPublisher)
 
-        def logoutHandlerNames = ConfigurationHolder.config.grails.plugins.springsecurity.logout.handlerNames ?: SpringSecurityUtils.LOGOUT_HANDLER_NAMES
+        def logoutHandlerNames = application.config.grails.plugins.springsecurity.logout.handlerNames ?: SpringSecurityUtils.LOGOUT_HANDLER_NAMES
         logoutHandlerNames << 'springSecurityEventLogger'
     }
 }

--- a/grails-app/domain/ca/redtoad/eventlog/SpringSecurityEvent.groovy
+++ b/grails-app/domain/ca/redtoad/eventlog/SpringSecurityEvent.groovy
@@ -6,6 +6,7 @@ class SpringSecurityEvent {
     String sessionId
     String eventName
     String remoteAddress
+    String switchedUsername
     Date dateCreated
 
     static constraints = {
@@ -13,6 +14,7 @@ class SpringSecurityEvent {
         sessionId(nullable: true)
         eventName()
         remoteAddress()
+        switchedUsername(nullable: true)
         dateCreated()
     }
 

--- a/test/unit/ca/redtoad/eventlog/SpringSecurityEventLoggerTests.groovy
+++ b/test/unit/ca/redtoad/eventlog/SpringSecurityEventLoggerTests.groovy
@@ -1,8 +1,11 @@
 package ca.redtoad.eventlog
 
+import grails.test.mixin.TestFor
+import grails.test.mixin.TestMixin
 import grails.test.mixin.domain.DomainClassUnitTestMixin
 import org.springframework.security.authentication.TestingAuthenticationToken
 import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.web.authentication.switchuser.AuthenticationSwitchUserEvent
 
 @TestMixin(DomainClassUnitTestMixin)
 class SpringSecurityEventLoggerTests extends GroovyTestCase {
@@ -12,13 +15,14 @@ class SpringSecurityEventLoggerTests extends GroovyTestCase {
     void testLogAuthenticationEventWithNullAuthentication() {
         mockDomain(SpringSecurityEvent)
 
-        logger.logAuthenticationEvent("event", null, "127.0.0.1")
+        logger.logAuthenticationEvent("event", null, "127.0.0.1", null)
 
         assert SpringSecurityEvent.count() == 1
         def event = SpringSecurityEvent.list().first()
         assert event.username == null
         assert event.sessionId == null
         assert event.eventName == "event"
+        assert event.switchedUsername == null
         assert event.remoteAddress == "127.0.0.1"
     }
 
@@ -26,13 +30,14 @@ class SpringSecurityEventLoggerTests extends GroovyTestCase {
         mockDomain(SpringSecurityEvent)
 
         def authentication = new TestingAuthenticationToken("username", [])
-        logger.logAuthenticationEvent("event", authentication, "127.0.0.1")
+        logger.logAuthenticationEvent("event", authentication, "127.0.0.1", null)
 
         assert SpringSecurityEvent.count() == 1
         def event = SpringSecurityEvent.list().first()
         assert event.username == "username"
         assert event.sessionId == null
         assert event.eventName == "event"
+        assert event.switchedUsername == null
         assert event.remoteAddress == "127.0.0.1"
     }
 
@@ -41,13 +46,33 @@ class SpringSecurityEventLoggerTests extends GroovyTestCase {
 
         def principal = { -> "username" } as UserDetails
         def authentication = new TestingAuthenticationToken(principal, [])
-        logger.logAuthenticationEvent("event", authentication, "127.0.0.1")
+        logger.logAuthenticationEvent("event", authentication, "127.0.0.1", null)
 
         assert SpringSecurityEvent.count() == 1
         def event = SpringSecurityEvent.list().first()
         assert event.username == "username"
         assert event.sessionId == null
         assert event.eventName == "event"
+        assert event.switchedUsername == null
+        assert event.remoteAddress == "127.0.0.1"
+    }
+
+    void testLogAuthenticationSwitchUserEvent() {
+        mockDomain(SpringSecurityEvent)
+
+        def principal = { -> "username" } as UserDetails
+        def authentication = new TestingAuthenticationToken(principal, [])
+        authentication.details = [remoteAddress: '127.0.0.1', sessionId: 'mockSessionId']
+        def targetUser = { -> "switchedUsername" } as UserDetails
+
+        logger.onApplicationEvent(new AuthenticationSwitchUserEvent(authentication, targetUser))
+
+        assert SpringSecurityEvent.count() == 1
+        def event = SpringSecurityEvent.list().first()
+        assert event.username == "username"
+        assert event.sessionId == "mockSessionId"
+        assert event.eventName == "AuthenticationSwitchUserEvent"
+        assert event.switchedUsername == "switchedUsername"
         assert event.remoteAddress == "127.0.0.1"
     }
 


### PR DESCRIPTION
Mr. Taylor,
  The subject says it all.  I have a project that will be using the switch user feature of Spring Security.  Your plugin did not log the important detail of this event, so I added it and hence this pull request.  Please see summary of change below.

I would be most happy if you decide to merge this change into your plugin's master.

Best Regards,
  Ressom
## Summary of change:
- Updated domain object
- Updated main logger object
- Removed deprecated usages in plugin definition
- Added unit test and updated existing tests
- Updated README.md to reflect new features.
